### PR TITLE
[Infinite recursion handling]

### DIFF
--- a/include/analyze/tail_call_analyze.hpp
+++ b/include/analyze/tail_call_analyze.hpp
@@ -1,0 +1,180 @@
+// analyze/tail_call_analyze.hpp
+#pragma once
+
+#include "node.hpp"
+#include "detail/ivisitor.hpp"
+
+struct TailCallSignal
+{
+    std::vector<AST::detail::Value> args;
+};
+
+class TailCallAnalyzer : public Visitor {
+public:
+    explicit TailCallAnalyzer(const AST::detail::Name funcName)
+        : funcName_(funcName), inTailPosition_(true) {}
+
+    void analyze(AST::INode* node) {
+        MSG("STARTED ANALYZING FOR TAIL RECURSION\n");
+        node->accept(*this);
+    }
+
+private:
+    std::string funcName_;
+    bool inTailPosition_;
+
+
+    void Visit(AST::ScopeNode& scopeNode) override {
+        const auto& children = scopeNode.get_children();
+
+        for (size_t i = 0; i < children.size(); ++i) {
+            bool wasTail = inTailPosition_;
+            inTailPosition_ = (i == children.size() - 1) && wasTail;
+
+            children[i]->accept(*this);
+
+            inTailPosition_ = wasTail;
+        }
+    }
+
+    void Visit(AST::ReturnNode& returnNode) override {
+        bool wasTail = inTailPosition_;
+        inTailPosition_ = true;
+
+        if (auto* expr = returnNode.get_expr()) {
+            expr->accept(*this);
+        }
+
+        inTailPosition_ = wasTail;
+    }
+
+        static std::optional<std::string_view> get_callee_name(const AST::ExprPtr& expr) {
+            MSG("Trying to get callee name...\n");
+            if (!expr) return std::nullopt;
+            if (auto* func = dynamic_cast<AST::FunctionNode*>(expr)) {
+
+                MSG("Successful dyn_cast to function node!\n");
+                LOG("Function has internal_name {}\n", func->get_internal_name());
+
+                return func->get_internal_name();
+            }
+
+            if (auto* var = dynamic_cast<AST::VariableNode*>(expr)) {
+
+                MSG("Successful dyn_cast to variable!\n");
+                LOG("Function has internal_name {}\n", var->get_name());
+
+                return var->get_name();
+            }
+
+        return std::nullopt;
+    }
+
+    void Visit(AST::CallNode& callNode) override {
+        bool wasTail = inTailPosition_;
+
+        for (auto* arg : callNode.get_args()) {
+            inTailPosition_ = false;
+            arg->accept(*this);
+        }
+
+        inTailPosition_ = wasTail;
+
+        if (inTailPosition_) {
+            auto calleeName = get_callee_name(callNode.get_callee());
+            LOG("Got calleeName = {}, funcName = {}\n", *calleeName, funcName_);
+            if (calleeName && *calleeName == funcName_) {
+                MSG("setting tail call to true... \n");
+                callNode.set_tail_call(true);
+                LOG("TCO: marked '{}' as tail call\n", *calleeName);
+            }
+        }
+    }
+
+
+    void Visit(AST::IfNode& ifNode) override {
+        bool wasTail = inTailPosition_;
+        inTailPosition_ = false;
+        ifNode.get_cond()->accept(*this);
+
+        inTailPosition_ = wasTail;
+        ifNode.get_action()->accept(*this);
+
+        if (auto* elseAction = ifNode.get_else_action()) {
+            inTailPosition_ = wasTail;
+            elseAction->accept(*this);
+        }
+    }
+
+
+    void Visit(AST::BinaryOpNode& binaryOpNode) override {
+        bool wasTail = inTailPosition_;
+        inTailPosition_ = false;
+        binaryOpNode.get_left()->accept(*this);
+        binaryOpNode.get_right()->accept(*this);
+        inTailPosition_ = wasTail;
+    }
+
+    void Visit(AST::FunctionNode& functionNode) override {
+    }
+
+    void Visit(AST::ConstantNode&) override {}
+    void Visit(AST::VariableNode&) override {}
+    void Visit(AST::AssignNode& assignNode) override {
+        bool wasTail = inTailPosition_;
+        inTailPosition_ = false;
+        assignNode.get_expr()->accept(*this);
+        inTailPosition_ = wasTail;
+    }
+    void Visit(AST::PrintNode& printNode) override {
+        bool wasTail = inTailPosition_;
+        inTailPosition_ = false;
+        printNode.get_expr()->accept(*this);
+        inTailPosition_ = wasTail;
+    }
+    void Visit(AST::InNode&) override {}
+    void Visit(AST::WhileNode& whileNode) override {
+        bool wasTail = inTailPosition_;
+        inTailPosition_ = false;
+        whileNode.get_cond()->accept(*this);
+        whileNode.get_scope()->accept(*this);
+        inTailPosition_ = wasTail;
+    }
+    void Visit(AST::ForNode& forNode) override {
+        bool wasTail = inTailPosition_;
+        inTailPosition_ = false;
+        if (forNode.get_init()) forNode.get_init()->accept(*this);
+        forNode.get_cond()->accept(*this);
+        forNode.get_body()->accept(*this);
+        if (forNode.get_iter()) forNode.get_iter()->accept(*this);
+        inTailPosition_ = wasTail;
+    }
+    void Visit(AST::UnaryOpNode& unaryOpNode) override {
+        bool wasTail = inTailPosition_;
+        inTailPosition_ = false;
+        unaryOpNode.get_operand()->accept(*this);
+        inTailPosition_ = wasTail;
+    }
+
+    void Visit(AST::ConditionalStatementNode&) override {}
+    void Visit(AST::StatementNode&) override {}
+    void Visit(AST::ExpressionNode&) override {}
+
+    void Visit(const AST::StatementNode&) const override {}
+    void Visit(const AST::ExpressionNode&) const override {}
+    void Visit(const AST::ConditionalStatementNode&) const override {}
+    void Visit(const AST::ScopeNode&) const override {}
+    void Visit(const AST::ForNode&) const override {}
+    void Visit(const AST::ConstantNode&) const override {}
+    void Visit(const AST::AssignNode&) const override {}
+    void Visit(const AST::WhileNode&) const override {}
+    void Visit(const AST::IfNode&) const override {}
+    void Visit(const AST::InNode&) const override {}
+    void Visit(const AST::VariableNode&) const override {}
+    void Visit(const AST::BinaryOpNode&) const override {}
+    void Visit(const AST::UnaryOpNode&) const override {}
+    void Visit(const AST::PrintNode&) const override {}
+    void Visit(const AST::FunctionNode&) const override {}
+    void Visit(const AST::CallNode&) const override {}
+    void Visit(const AST::ReturnNode&) const override {}
+};

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -255,12 +255,16 @@ class CallNode final : public ExpressionNode
 {
     ExprPtr              callee_;
     std::vector<ExprPtr> args_;
+    bool is_tail_call_ = false;
 public:
     CallNode(ExprPtr callee, std::vector<ExprPtr> args)
         : callee_(callee), args_(std::move(args)) {}
 
     void accept(      Visitor& visitor)       override {visitor.Visit(*this);}
     void accept(const Visitor& visitor) const override {visitor.Visit(*this);}
+
+    bool is_tail_call() const { return is_tail_call_; }
+    void set_tail_call(bool val) { is_tail_call_ = val; }
 
 public:
           ExprPtr get_callee() const { return callee_; }

--- a/include/tree_traverse.hpp
+++ b/include/tree_traverse.hpp
@@ -10,6 +10,7 @@
 #include "detail/context.hpp"
 #include "detail/value.hpp"
 #include "log.h"
+#include "analyze/tail_call_analyze.hpp"
 
 struct ReturnSignal
 {
@@ -62,6 +63,12 @@ private:
         if (std::holds_alternative<int>(value))
             return "int";
         return "func";
+    }
+
+    void clear_stack() {
+        while (!eval_stack_.empty()) {
+            eval_stack_.pop();
+        }
     }
 
     void push_value(const Value& value)
@@ -355,8 +362,11 @@ public:
 
         if (functionNode.has_internal_name())
         {
+
             functionObject->internalName    = functionNode.get_internal_name();
             functionObject->hasInternalName = true;
+
+            ctx_.current_->vars[functionObject->internalName] = functionObject;
 
             auto recursiveEnvironment    = std::make_shared<AST::detail::Frame>();
             recursiveEnvironment->parent = ctx_.current_;
@@ -364,7 +374,10 @@ public:
             functionObject->env          = recursiveEnvironment;
 
             LOG("FUNC: internalName='{}'\n", functionObject->internalName);
+            TailCallAnalyzer analyzer(functionObject->internalName);
+            analyzer.analyze(functionObject->body);
         }
+
 
         push_value(Value{functionObject});
     }
@@ -391,6 +404,11 @@ public:
         if (evaluatedArguments.size() != functionObject->params.size())
             throw std::runtime_error("Arity mismatch in function call");
 
+        if (callNode.is_tail_call()) {
+            MSG("CALL: TCO detected, reusing frame\n");
+            throw TailCallSignal(std::move(evaluatedArguments));
+        }
+
         auto savedFrame   = ctx_.current_;
         auto callFrame    = std::make_shared<AST::detail::Frame>();
         callFrame->parent = functionObject->env;
@@ -403,21 +421,36 @@ public:
         }
 
         ctx_.current_ = callFrame;
+        while (true) {
+            try
+            {
+                functionObject->body->accept(*this);
+                Value functionResult = pop_value();
+                ctx_.current_ = savedFrame;
 
-        try
-        {
-            functionObject->body->accept(*this);
-            Value functionResult = pop_value();
-            ctx_.current_ = savedFrame;
-
-            LOG("CALL: normal return kind={}\n", value_kind(functionResult));
-            push_value(functionResult);
-        }
-        catch (const ReturnSignal& returnSignal)
-        {
-            ctx_.current_ = savedFrame;
-            LOG("CALL: explicit return kind={}\n", value_kind(returnSignal.value));
-            push_value(returnSignal.value);
+                LOG("CALL: normal return kind={}\n", value_kind(functionResult));
+                push_value(functionResult);
+                break;
+            }
+            catch (const ReturnSignal& returnSignal)
+            {
+                ctx_.current_ = savedFrame;
+                LOG("CALL: explicit return kind={}\n", value_kind(returnSignal.value));
+                push_value(returnSignal.value);
+                break;
+            }
+            catch (const TailCallSignal& tcoSignal) {
+                ctx_.current_ = savedFrame;
+                MSG("TCO CALL caught! \n");
+                for (size_t index = 0; index < tcoSignal.args.size(); ++index)
+                {
+                    std::string_view paramName = functionObject->params[index];
+                    savedFrame->vars[paramName] = tcoSignal.args[index];
+                    LOG("CALL: TCO update param '{}'\n", std::string(paramName).c_str());
+                }
+                clear_stack();
+                continue;
+            }
         }
     }
 

--- a/unit_tests/data/common/func_infinite_recursion.dat
+++ b/unit_tests/data/common/func_infinite_recursion.dat
@@ -1,0 +1,9 @@
+fact = func(x, y) : factorial {
+  res = x * y;
+  print(res);
+  return factorial(res, y - 1);
+};
+
+fact(5, 4);
+
+

--- a/utils/log.h
+++ b/utils/log.h
@@ -2,6 +2,8 @@
 
 #include <iostream>
 
+// #define ENABLE_LOGGING
+
 #if defined(__has_include)
 #  if __has_include(<format>)
 #    include <format>
@@ -29,7 +31,7 @@
 #define LOG(msg, ...)                                                          \
     do                                                                         \
     {                                                                          \
-        std::clog << __FUNCTION__ << ": "                                      \
+        std::clog << __FUNCTION__ << ": ";                                     \
         std::clog << std::format(msg, __VA_ARGS__);                            \
     }                                                                          \
     while (false)
@@ -59,11 +61,11 @@
     while (false)
 
 #define LLVM_PRINT(value)                                                      \
-    do                                                                         \
-    {                                                                          \
-        (value)->print(llvm::errs());                                          \
-    }                                                                          \
-    while (false)
+    // do                                                                         \
+    // {                                                                          \
+    //     (value)->print(llvm::errs());                                          \
+    // }                                                                          \
+    // while (false)
 
 #else
 


### PR DESCRIPTION
1. interpretator would seg fault when coming into infinite recursing and eat a lot of memory, because it would always create a new stack frame when coming inside a call. however, in some cases this can be optimized if we have a tail recursion pattern. in this case we can reuse the same stack frame and our recursion will turn into cycle where we constantly update stack frame.
2. The implementation consists of new class - TailCallAnalyzer, which analyzes AST while interpretation (callled from FunctionNode). There is a check inside to proof that there is an ability for TCO.
3. Tail recursion description from Vladimirov Toolchain book - 'Calling procedure f from procedure g is- tail recursive call if the only thing that g does after f returns is also returns control.' Maybe this description will help to get the idea of what's going on in CallNode visitor of TailCallAnalyzer class.
4. Then we throw a TCOSignal in CallNode while traversing. If it is caught, we get into cycle, where our stack frame is being updated...